### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/Omni-rs/omni-box/releases/tag/v0.1.0) - 2024-12-10
+
+### Added
+
+- added github action to publish
+
+### Fixed
+
+- update license and metadata before publishing
+
+### Other
+
+- Update release-plz.yml
+- Update Cargo.toml
+- Update LICENSE-APACHE
+- fixed lint warnings
+- provisional addresses
+- github actions
+- added licenses and rust project config files
+- readme
+- changed config file name
+- updated dependencies
+- updated contexts, added accounts and extended example
+- fixed config for near client
+- added contexts and renamed nodes
+- added clients
+- before refactor omnibox struct
+- before delete omni json rpc
+- before applying refactor
+- all compiling but still lots of TODOs
+- first commit


### PR DESCRIPTION
## 🤖 New release
* `omni-box`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/Omni-rs/omni-box/releases/tag/v0.1.0) - 2024-12-10

### Added

- added github action to publish

### Fixed

- update license and metadata before publishing

### Other

- Update release-plz.yml
- Update Cargo.toml
- Update LICENSE-APACHE
- fixed lint warnings
- provisional addresses
- github actions
- added licenses and rust project config files
- readme
- changed config file name
- updated dependencies
- updated contexts, added accounts and extended example
- fixed config for near client
- added contexts and renamed nodes
- added clients
- before refactor omnibox struct
- before delete omni json rpc
- before applying refactor
- all compiling but still lots of TODOs
- first commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).