### PR TITLE
added default evm balance to derived account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "omni-box"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "alloy",
  "bitcoin",
@@ -3960,14 +3960,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
+ "tiny-keccak",
  "tokio",
 ]
 
 [[package]]
 name = "omni-transaction"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a975a9a70511c9f84d5284821e5d767283b5c3f6789b038b47b34760985ecbc0"
+checksum = "4f691db7557adeb52bd376199871f5278b776d1b70ce9ad6620f7e806fb93aed"
 dependencies = [
  "borsh",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-box"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"
@@ -24,7 +24,7 @@ near-crypto = { version = "0.25.0" }
 near-jsonrpc-client = { version = "0.12.0" }
 near-jsonrpc-primitives = "0.25.0"
 near-sdk = { version = "5.3.0", features = ["schemars"] }
-omni-transaction = "0.1.1"
+omni-transaction = "0.1.3"
 # bitcoin
 bitcoin = { version = "0.32.0", default-features = false, features = [
     "std",
@@ -38,6 +38,7 @@ bitcoind = { package = "bitcoind-json-rpc-regtest", version = "0.3.0", features 
     "26_0",
 ] }
 sha3 = "0.10.8"
+tiny-keccak = "2.0.2"
 k256 = { version = "0.13.1", features = [
     "sha256",
     "ecdsa",

--- a/src/chain_config.rs
+++ b/src/chain_config.rs
@@ -27,7 +27,7 @@ pub struct ChainOverrides {
 impl ChainConfig {
     pub fn default(network: Network) -> Self {
         match network {
-            Network::Ethereum => Self {
+            Network::EVM => Self {
                 node_url: "http://localhost:8545".to_string(),
                 node_instance: None,
                 accounts: vec![None],

--- a/src/contexts/evm/evm_context.rs
+++ b/src/contexts/evm/evm_context.rs
@@ -27,9 +27,20 @@ type Provider = FillProvider<
     Ethereum,
 >;
 
+type DefaultProvider = FillProvider<
+    JoinFill<
+        Identity,
+        JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
+    >,
+    RootProvider<Http<Client>>,
+    Http<Client>,
+    Ethereum,
+>;
+
 #[derive(Debug)]
 pub struct EVMTestContext {
     pub anvil: AnvilInstance,
+    pub provider: DefaultProvider,
     pub alice: EthereumWallet,
     pub bob: EthereumWallet,
 }
@@ -49,7 +60,16 @@ impl EVMTestContext {
         let alice = EthereumWallet::from(alice_signer);
         let bob = EthereumWallet::from(bob_signer);
 
-        Self { anvil, alice, bob }
+        let provider = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .on_http(anvil.endpoint_url());
+
+        Self {
+            anvil,
+            alice,
+            bob,
+            provider,
+        }
     }
 
     pub const fn alice(&self) -> &EthereumWallet {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Network {
     EVM,

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Network {
-    Ethereum,
+    EVM,
     Near,
     Bitcoin,
 }

--- a/src/omni_box.rs
+++ b/src/omni_box.rs
@@ -93,7 +93,7 @@ impl OmniBox {
 
         // Calculate default derived addresses EVM
         let evm_derived_address =
-            address::get_derived_address_for_evm(&deployer_account.account_id, &options.evm_path);
+            address::get_derived_address_for_evm(&deployer_account.account_id, options.evm_path);
 
         println!("EVM Derived Address: {:?}", evm_derived_address.address);
 

--- a/src/omni_box_options.rs
+++ b/src/omni_box_options.rs
@@ -7,15 +7,22 @@ pub struct OmniBoxOptions {
     pub overrides: HashMap<Network, ChainOverrides>, // Overrides for each network
     pub path: &'static str,                          // Path to the config file
     pub default_near_network: NearNetworkConfig,     // Default Near network
+    pub btc_path: &'static str,                      // Default path of the Bitcoin address
+    pub evm_path: &'static str,                      // Default path of the EVM address
 }
+
+const DEFAULT_BTC_PATH: &str = "bitcoin-1";
+const DEFAULT_EVM_PATH: &str = "ethereum-1";
 
 impl Default for OmniBoxOptions {
     fn default() -> Self {
         Self {
-            modules: vec![Network::Ethereum, Network::Near, Network::Bitcoin],
+            modules: vec![Network::EVM, Network::Near, Network::Bitcoin],
             overrides: HashMap::new(),
             path: "./",
             default_near_network: NearNetworkConfig::Testnet,
+            btc_path: DEFAULT_BTC_PATH,
+            evm_path: DEFAULT_EVM_PATH,
         }
     }
 }

--- a/src/utils/signature.rs
+++ b/src/utils/signature.rs
@@ -1,5 +1,6 @@
 use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::secp256k1::{self};
+use hex::FromHex;
 use near_jsonrpc_client::methods::tx::RpcTransactionResponse;
 use near_primitives::views::{ExecutionStatusView, FinalExecutionStatus};
 
@@ -83,7 +84,7 @@ pub fn extract_multiple_signatures(
     Ok(signatures)
 }
 
-pub fn extract_signed_transaction(response: &RpcTransactionResponse) -> Result<String, String> {
+pub fn extract_signed_transaction(response: &RpcTransactionResponse) -> Result<Vec<u8>, String> {
     if let Some(near_primitives::views::FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(
         final_outcome,
     )) = &response.final_execution_outcome
@@ -93,10 +94,37 @@ pub fn extract_signed_transaction(response: &RpcTransactionResponse) -> Result<S
             let success_value_str =
                 String::from_utf8(success_value.clone()).map_err(|e| e.to_string())?;
 
-            // Remove the quotes from the string
-            let hex_tx = success_value_str.trim_matches('"');
+            let trimmed_value = success_value_str.trim_matches('"');
 
-            return Ok(hex_tx.to_string());
+            let parsed_bytes = Vec::from_hex(&trimmed_value)
+                .map_err(|e| format!("Failed to decode hex: {}", e))?;
+
+            return Ok(parsed_bytes);
+        }
+    }
+
+    Err("Failed to extract signed transaction".to_string())
+}
+
+pub fn extract_payload(response: &RpcTransactionResponse) -> Result<[u8; 32], String> {
+    if let Some(near_primitives::views::FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(
+        final_outcome,
+    )) = &response.final_execution_outcome
+    {
+        if let FinalExecutionStatus::SuccessValue(success_value) = &final_outcome.status {
+            // Convert the success value to a string
+            let success_value_str =
+                String::from_utf8(success_value.clone()).map_err(|e| e.to_string())?;
+
+            let parsed_bytes: Vec<u8> = serde_json::from_str(&success_value_str)
+                .map_err(|e| format!("Failed to parse JSON: {}", e))?;
+
+            // Ensure the parsed bytes have the correct length
+            let fixed_array: [u8; 32] = parsed_bytes
+                .try_into()
+                .map_err(|_| "Parsed bytes are not 32 bytes long".to_string())?;
+
+            return Ok(fixed_array);
         }
     }
 

--- a/src/utils/signature.rs
+++ b/src/utils/signature.rs
@@ -96,8 +96,8 @@ pub fn extract_signed_transaction(response: &RpcTransactionResponse) -> Result<V
 
             let trimmed_value = success_value_str.trim_matches('"');
 
-            let parsed_bytes = Vec::from_hex(&trimmed_value)
-                .map_err(|e| format!("Failed to decode hex: {}", e))?;
+            let parsed_bytes =
+                Vec::from_hex(trimmed_value).map_err(|e| format!("Failed to decode hex: {}", e))?;
 
             return Ok(parsed_bytes);
         }


### PR DESCRIPTION
This PR adds the following:

- fixes the evm address calculation
- add btc path and evm path as options of the omnibox
- calculates by default the derived address of evm, btc legacy and btc segwit
- set balance of the default derived evm address to 100