### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/Omni-rs/omni-box/compare/v0.1.4...v0.1.5) - 2025-01-20
+
+### Fixed
+
+- fixed comments
+- changelog update
+
 ## [0.1.0](https://github.com/Omni-rs/omni-box/releases/tag/v0.1.0) - 2024-12-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "omni-box"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "alloy",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-box"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `omni-box`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/Omni-rs/omni-box/compare/v0.1.4...v0.1.5) - 2025-01-20

### Fixed

- fixed comments
- changelog update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).